### PR TITLE
Extend till the end of year (fixes #99)

### DIFF
--- a/WPinternals/Config/Registration.cs
+++ b/WPinternals/Config/Registration.cs
@@ -33,7 +33,7 @@ namespace WPinternals.Config
         internal const bool IsPrerelease = false;
 #endif
 
-        internal static readonly DateTime ExpirationDate = new(2025, 06, 21);
+        internal static readonly DateTime ExpirationDate = new(2025, 12, 31);
 
         internal static void CheckExpiration()
         {


### PR DESCRIPTION
Extends the timebomb till the end of the year

Please rebuild the binaries and update them in the gh release to make the preview release usable again